### PR TITLE
migrate CLI from click to cappa

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,24 @@ Once installed, you can run the command with the `--help` option.
 
 ```shell
 ❯ army-days --help
-Usage: army-days [OPTIONS]
+Usage: army-days [-f FILENAME] [-g] [-p SHOW_PAST] [-a] [-h] [-v]
 
-Options:
-  --version                Show the version and exit.
-  -f, --filename PATH      configuration file; by default searches:
-                           ./days.yaml ./days.json ~/days.yaml ~/days.json
-                           ~/.days.yaml ~/.days.json.
-  -g, --generate-sample    generate sample data in yaml format (sends to
-                           stdout).
-  -p, --show-past INTEGER  show past events; optionally limit to events within
-                           the past X days (e.g., --show-past or --show-past
-                           365).
-  --help                   Show this message and exit.
+  day countdown program (python edition)
+
+  Options
+    [-f, --filename FILENAME]    configuration file; by default searches:
+                                 ./days.yaml ./days.json ~/days.yaml
+                                 ~/days.json ~/.days.yaml ~/.days.json.
+    [-g, --generate-sample]      generate sample data in yaml format (sends to
+                                 stdout).
+    [-p, --show-past SHOW_PAST]  show past events within the past N days (use 0
+                                 to show all past events).
+    [-a, --show-all]             show all future events, bypassing
+                                 max_days_future config limit.
+
+  Help
+    [-h, --help]                 Show this message and exit.
+    [-v, --version]              Show the version and exit.
 ```
 
 ### Configuration / Input file
@@ -82,11 +87,11 @@ Army-days provides multiple ways to display past events:
 
 #### Command-line option
 
-Use the `-p` / `--show-past` flag to show past events:
+Use the `-p` / `--show-past` option to show past events. It always takes an integer day-limit; pass `0` to show *all* past events:
 
 ```shell
 # Show all past events
-army-days --show-past
+army-days --show-past 0
 
 # Show only past events within the last 365 days
 army-days --show-past 365

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "army-days"
-version = "0.5.0"
+version = "0.6.0"
 description = "day countdown program (python edition)"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,12 @@ version = "0.5.0"
 description = "day countdown program (python edition)"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["click>=8.1.7", "pydantic>=2.9.1", "pyyaml>=6.0.2", "python-dateutil>=2.9.0"]
+dependencies = [
+    "pydantic>=2.9.1",
+    "pyyaml>=6.0.2",
+    "python-dateutil>=2.9.0",
+    "cappa>=0.31.0",
+]
 license-expression = "MIT"
 
 [build-system]

--- a/src/army_days/cli.py
+++ b/src/army_days/cli.py
@@ -1,7 +1,10 @@
 import os
 import sys
+from dataclasses import dataclass
+from importlib.metadata import version as pkg_version
+from typing import Annotated
 
-import click
+import cappa
 import yaml
 import yaml.scanner
 from pydantic_core import ValidationError
@@ -13,52 +16,61 @@ from .output import output_events
 from .utils import find_default_config_file
 
 
-@click.command()
-@click.version_option()
-@click.option(
-    "-f",
-    "--filename",
-    type=click.Path(),
-    default="",
-    help=f"configuration file; by default searches: {"\n".join(DEFAULT_CONFIG_FILES)}.",
-)
-@click.option(
-    "-g",
-    "--generate-sample",
-    is_flag=True,
-    show_default=True,
-    default=False,
-    help="generate sample data in yaml format (sends to stdout).",
-)
-@click.option(
-    "-p",
-    "--show-past",
-    type=int,
-    is_flag=False,
-    flag_value=0,
-    default=None,
-    help="show past events; optionally limit to events within the past X days (e.g., --show-past or --show-past 365).",
-)
-@click.option(
-    "-a",
-    "--show-all",
-    is_flag=True,
-    show_default=True,
-    default=False,
-    help="show all future events, bypassing max_days_future config limit.",
-)
-def main(filename, generate_sample, show_past, show_all):
-    if generate_sample:
+def run(army_days: "ArmyDays") -> None:
+    if army_days.generate_sample:
         print(yaml.dump(generate_default_configuration().model_dump(mode="json")))
-    else:
-        config_filename = filename or find_default_config_file()
-        if not config_filename or not os.path.exists(config_filename):
-            sys.stderr.write(f"\nConfiguration file: '{config_filename}' not found.\n")
+        return
+    config_filename = army_days.filename or find_default_config_file()
+    if not config_filename or not os.path.exists(config_filename):
+        sys.stderr.write(f"\nConfiguration file: '{config_filename}' not found.\n")
+        sys.exit(1)
+    with open(config_filename) as file:
+        try:
+            data = DaysModel(**yaml.load(file.read().replace("\t", " "), yaml.SafeLoader))
+        except (yaml.scanner.ScannerError, yaml.error.YAMLError, ValidationError) as ex:
+            sys.stderr.write(f"\nError parsing configuration file: {file.name} error: {ex}\n")
             sys.exit(1)
-        with open(config_filename) as file:
-            try:
-                data = DaysModel(**yaml.load(file.read().replace("\t", " "), yaml.SafeLoader))
-            except (yaml.scanner.ScannerError, yaml.error.YAMLError, ValidationError) as ex:
-                sys.stderr.write(f"\nError parsing configuration file: {file.name} error: {ex}\n")
-                sys.exit(1)
-            output_events(compute_results(data, show_past_days=show_past, show_all_future=show_all))
+        output_events(
+            compute_results(data, show_past_days=army_days.show_past, show_all_future=army_days.show_all)
+        )
+
+
+@cappa.command(name="army-days", help="day countdown program (python edition)", invoke=run)
+@dataclass
+class ArmyDays:
+    filename: Annotated[
+        str,
+        cappa.Arg(
+            short="-f",
+            long="--filename",
+            help=f"configuration file; by default searches: {' '.join(DEFAULT_CONFIG_FILES)}.",
+        ),
+    ] = ""
+    generate_sample: Annotated[
+        bool,
+        cappa.Arg(
+            short="-g",
+            long="--generate-sample",
+            help="generate sample data in yaml format (sends to stdout).",
+        ),
+    ] = False
+    show_past: Annotated[
+        int | None,
+        cappa.Arg(
+            short="-p",
+            long="--show-past",
+            help="show past events within the past N days (use 0 to show all past events).",
+        ),
+    ] = None
+    show_all: Annotated[
+        bool,
+        cappa.Arg(
+            short="-a",
+            long="--show-all",
+            help="show all future events, bypassing max_days_future config limit.",
+        ),
+    ] = False
+
+
+def main() -> None:
+    cappa.invoke(ArmyDays, version=pkg_version("army-days"))

--- a/src/army_days/core.py
+++ b/src/army_days/core.py
@@ -16,10 +16,13 @@ def compute_results(
         time_delta = (event_date - current).days
 
         # Apply max_days_future filtering for future events
-        if time_delta > 0 and not show_all_future:
-            if days.config.max_days_future is not None:
-                if time_delta > days.config.max_days_future:
-                    continue  # Skip this event
+        if (
+            time_delta > 0
+            and not show_all_future
+            and days.config.max_days_future is not None
+            and time_delta > days.config.max_days_future
+        ):
+            continue
 
         # Calculate days value (with "and a butt" logic)
         days_value = float(time_delta)
@@ -56,18 +59,15 @@ def compute_results(
             if days.config.show_completed:
                 should_show = True
 
-            # Check CLI parameter --show-past
-            if show_past_days is not None:
-                # If show_past_days is provided without a value, show all past events
-                # If it has a value, only show events within that many days in the past
-                if show_past_days == 0 or abs(time_delta) <= show_past_days:
-                    should_show = True
+            # Check CLI parameter --show-past (0 = show all past; otherwise only within N days)
+            if show_past_days is not None and (show_past_days == 0 or abs(time_delta) <= show_past_days):
+                should_show = True
 
-            # Check per-event always_show option
-            if entry.always_show:
-                # If show_past_limit is set, only show if within limit
-                if entry.show_past_limit is None or abs(time_delta) <= entry.show_past_limit:
-                    should_show = True
+            # Check per-event always_show option (show_past_limit caps how far back it applies)
+            if entry.always_show and (
+                entry.show_past_limit is None or abs(time_delta) <= entry.show_past_limit
+            ):
+                should_show = True
 
         if should_show:
             results.append(new_computed_event)

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "army-days"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "cappa" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "annotated-types"
@@ -16,7 +20,7 @@ name = "army-days"
 version = "0.5.0"
 source = { editable = "." }
 dependencies = [
-    { name = "click" },
+    { name = "cappa" },
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "pyyaml" },
@@ -32,7 +36,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.1.7" },
+    { name = "cappa", specifier = ">=0.31.0" },
     { name = "pydantic", specifier = ">=2.9.1" },
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
@@ -56,15 +60,17 @@ wheels = [
 ]
 
 [[package]]
-name = "click"
-version = "8.3.1"
+name = "cappa"
+version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "type-lens" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/42/c63e45ba87862c63d5cdf2146ad1b00c2e9d4da4be08309518d4401cd6ba/cappa-0.31.0.tar.gz", hash = "sha256:070ccdefa418c8cad81c282d265196b0a03f2ad0c159a84f7f75b7b24ab0f317", size = 319910, upload-time = "2025-12-04T15:59:38.373Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/2e/fa028f325e51a37ca22099a628ef30b40fe12b9b3dbdb66b396446696267/cappa-0.31.0-py3-none-any.whl", hash = "sha256:e8575e383b42c67c797ec0c15fc7b1debcc7249e42147c294a867baffde9b841", size = 68922, upload-time = "2025-12-04T15:59:36.805Z" },
 ]
 
 [[package]]
@@ -245,6 +251,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "matplotlib-inline"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -254,6 +272,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -509,6 +536,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -538,6 +578,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "type-lens"
+version = "0.2.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/55/8846322acedf26cafb4a66dd23fdca6bc73cb3f8c0029040a9b96f5aa0dd/type_lens-0.2.6.tar.gz", hash = "sha256:5d46ab3bc2dfafc174cad702eccb4418c31e38e258e87945a19d86ebc204d08b", size = 362277, upload-time = "2025-10-20T20:08:28.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/c5/30de077e06f7ffc3fe21d45ce26b8088816227b678a7157f6b9e080ff2db/type_lens-0.2.6-py3-none-any.whl", hash = "sha256:aade6beb3eca337c90d1b627b509768473bbd591e233ed6b57fb93ec2a01bca6", size = 14451, upload-time = "2025-10-20T20:08:26.936Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Rewrite the CLI as a cappa @command dataclass with cappa.invoke wiring the parsed instance into a run() callback. The version now comes from importlib.metadata.

Behavior change: --show-past now always takes an integer; pass 0 to show all past events (cappa 0.31 has no equivalent of click's flag_value optional-value semantics). README updated to match.

Also collapse four nested-if blocks in core.py flagged by ruff SIM102 while we're here.